### PR TITLE
feat: combine months into a unified calendar grid with clear breaks

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -46,8 +46,6 @@ function getDisplayRange(periods) {
   };
 }
 
-let isContinuousView = true;
-
 function renderUnifiedCalendar(startMonth, endMonth, dayMap, todayKey, labels) {
   const wrapper = document.createElement("div");
   wrapper.className = "calendar-unified";
@@ -68,6 +66,12 @@ function renderUnifiedCalendar(startMonth, endMonth, dayMap, todayKey, labels) {
   let curMonthStart = new Date(startMonth);
   let curDow = curMonthStart.getDay();
 
+  // Divider for the very first month
+  const firstDivider = document.createElement("div");
+  firstDivider.className = "month-divider";
+  firstDivider.textContent = `${MONTH_NAMES[curMonthStart.getMonth()]} ${curMonthStart.getFullYear()}`;
+  grid.appendChild(firstDivider);
+
   // Initial padding
   for (let i = 0; i < curDow; i++) {
     const empty = document.createElement("div");
@@ -75,7 +79,6 @@ function renderUnifiedCalendar(startMonth, endMonth, dayMap, todayKey, labels) {
     grid.appendChild(empty);
   }
 
-  let monthIndex = 0; // To alternate month shading
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
@@ -100,17 +103,6 @@ function renderUnifiedCalendar(startMonth, endMonth, dayMap, todayKey, labels) {
       if (d === 1) {
         cell.id = firstDayCellId;
         window.monthNavAnchors[firstDayCellId] = cell;
-      }
-
-      if (isContinuousView) {
-        if (monthIndex % 2 !== 0) cell.classList.add("day--alt-month");
-        if (d === 1 && curMonthStart > startMonth) {
-           cell.classList.add("day--month-start");
-           const monthLbl = document.createElement("span");
-           monthLbl.className = "day__month-label";
-           monthLbl.textContent = MONTH_NAMES[month].slice(0,3);
-           cell.appendChild(monthLbl);
-        }
       }
 
       if (info) {
@@ -166,9 +158,8 @@ function renderUnifiedCalendar(startMonth, endMonth, dayMap, todayKey, labels) {
     }
 
     curMonthStart = new Date(year, month + 1, 1);
-    monthIndex++;
 
-    if (!isContinuousView && curMonthStart <= endMonth) {
+    if (curMonthStart <= endMonth) {
       // Pad out the rest of the week
       if (curDow !== 0) {
         for (let i = curDow; i < 7; i++) {
@@ -211,14 +202,10 @@ export function renderCalendar({ periods, ownerName, texasCity, floridaCity }) {
   // Store data globally for re-rendering
   window.calendarData = { startMonth, endMonth, dayMap, todayKey, labels };
 
-  function doRender() {
-    container.innerHTML = "";
-    container.className = isContinuousView ? "continuous-view" : "break-view";
-    const unified = renderUnifiedCalendar(startMonth, endMonth, dayMap, todayKey, labels);
-    container.appendChild(unified);
-  }
-
-  doRender();
+  container.innerHTML = "";
+  container.className = "break-view";
+  const unified = renderUnifiedCalendar(startMonth, endMonth, dayMap, todayKey, labels);
+  container.appendChild(unified);
 
   // Wire up the "Jump to today" button
   const jumpBtn = document.getElementById("jump-today");
@@ -229,16 +216,6 @@ export function renderCalendar({ periods, ownerName, texasCity, floridaCity }) {
       }
     });
     jumpBtn.setAttribute("data-bound", "true");
-  }
-
-  // Wire up toggle button
-  const toggleBtn = document.getElementById("toggle-view");
-  if (toggleBtn && !toggleBtn.hasAttribute("data-bound")) {
-    toggleBtn.addEventListener("click", () => {
-      isContinuousView = !isContinuousView;
-      doRender();
-    });
-    toggleBtn.setAttribute("data-bound", "true");
   }
 
   // Build the quick-nav month list

--- a/index.html
+++ b/index.html
@@ -35,14 +35,13 @@
           Unknown
         </div>
       </nav>
-      <button id="toggle-view" aria-label="Toggle layout view">Toggle View</button>
       <button id="jump-today" aria-label="Scroll to today">Today</button>
     </div>
   </header>
 
   <nav id="month-nav" class="month-nav-bar" aria-label="Jump to month"></nav>
 
-  <main id="calendar" aria-label="Texas and Florida schedule calendar" class="continuous-view"></main>
+  <main id="calendar" aria-label="Texas and Florida schedule calendar" class="break-view"></main>
 
   <footer class="site-footer">
     <p>Last updated <span id="last-updated"></span></p>

--- a/style.css
+++ b/style.css
@@ -99,8 +99,8 @@ body {
 .legend__swatch--uncertain { background: var(--color-uncertain); }
 .legend__swatch--unknown  { background: var(--color-unknown); }
 
-/* ─── Buttons ──────────────────────────────────────────────── */
-#jump-today, #toggle-view {
+/* ─── Jump to today button ──────────────────────────────────────────────── */
+#jump-today {
   padding: 0.35rem 0.75rem;
   font-size: 0.8rem;
   font-weight: 600;
@@ -113,12 +113,7 @@ body {
   transition: opacity 0.15s;
   white-space: nowrap;
 }
-#jump-today:hover, #toggle-view:hover { opacity: 0.85; }
-
-#toggle-view {
-  background: var(--color-muted);
-  margin-right: 0.5rem;
-}
+#jump-today:hover { opacity: 0.85; }
 
 /* ─── Month nav ─────────────────────────────────────────────────────────── */
 #month-nav {
@@ -195,28 +190,6 @@ body {
   content: "";
   flex: 1;
   border-bottom: 1px dashed var(--color-border);
-}
-
-/* Alternate month shading in continuous view */
-.day--alt-month {
-  filter: brightness(0.95) contrast(1.05);
-}
-
-/* Month label in continuous view */
-.day__month-label {
-  position: absolute;
-  top: 4px;
-  left: 5px;
-  font-size: 0.6rem;
-  font-weight: 700;
-  color: var(--color-text);
-  opacity: 0.6;
-  z-index: 1;
-}
-
-/* Border indication for month start in continuous view */
-.day--month-start {
-  border-left: 2px dashed var(--color-muted);
 }
 
 /* ─── Day-of-week header ────────────────────────────────────────────────── */


### PR DESCRIPTION
- Replaced the separate month section layout with a single unified CSS grid.
- Implemented a single, contiguous calendar view where each month starts on its proper day of the week, with empty cells padding the remainder of the previous month's final week.
- Added full-width dashed dividers with month labels to separate each month visually (and to label the very first month).
- Updated jump-to anchors ("Jump to Today" and month quick-nav) to point to the new day cells within the unified grid.